### PR TITLE
Add GroupMembers When Groups Edited

### DIFF
--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -8,7 +8,10 @@
         = f.text_field :name, placeholder:"グループ名を入力してください", class: "chat-group-form__input"
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        = f.label :name, "チャットメンバーを追加", class: "chat-group-form__label"
+        = f.label :test, "チャットメンバーを追加", class: "chat-group-form__label"
+      .check_box
+        = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |b|
+          = b.label {b.check_box + b.text}
       .chat-group-form__field--right
         .chat-group-form__search.clearfix
           = f.text_field :name, placeholder:"追加したいユーザを入力してください", class: "chat-group-form__input"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -31,9 +31,8 @@
             = user.name
 
         .selected-group__edit-box 
-          - @groups.each do |group|
-            = link_to edit_group_path(group) do
-              .selected-group__edit-box__text Edit
+          = link_to edit_group_path(@group) do
+            .selected-group__edit-box__text Edit
       .message-area 
         .messages 
           .message-info


### PR DESCRIPTION
#What
グループ編集機能作成
#Why
ユーザが作成後のグループ情報を編集できるようにするため